### PR TITLE
Corrected catalogue generation if source not in LoTSS

### DIFF
--- a/plot_field.py
+++ b/plot_field.py
@@ -679,7 +679,7 @@ def generate_catalogues( RATar, DECTar, targRA = 0.0, targDEC = 0.0, lotss_radiu
     if len(lbcs_catalogue) == 0:
         logging.error('LBCS coverage does not exist, and catalogue not found on disk.')
         return
-    if len(lotss_catalogue) == 0 and not fail_lotss_ok:
+    if len(lotss_catalogue) == 0 and not continue_no_lotss:
         logging.error('LoTSS coverage does not exist, and contine_without_lotss is set to False.')
         return 
     
@@ -702,7 +702,7 @@ def generate_catalogues( RATar, DECTar, targRA = 0.0, targDEC = 0.0, lotss_radiu
         lbcs_catalogue.add_column( seps )
 
         ## rename the source_id column
-        #lbcs_catalogue.rename_column('Observation','Source_id')
+        lbcs_catalogue.rename_column('Observation','Source_id')
 
         ## add in some dummy data
         Total_flux = Column( np.ones(len(lbcs_catalogue))*1e3, name='Total_flux', unit='mJy' )


### PR DESCRIPTION
The script failed if used on observation data from sources not covered by LoTSS. The reason for this is that the option `continue_no_lotss` isn't used. 

Additionally, the catalogue generated by this script may cause issues during the VLBI pipeline, as it is left with an `Observation` column. The pipeline expects this column to be called `Source_id`. The replacement of this column name was present in the script, but commented out. This PR uncomments the replacement.